### PR TITLE
Shorten code

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,8 +1,7 @@
 pub fn generate_full_grid<T: Into<u32>>(image_size: T, hash: &[u8]) -> Vec<bool> {
     // Compute the hash value
     let square_count = (image_size.into() as usize).pow(2);
-    let grid: Vec<bool> = (0..square_count)
+    (0..square_count)
         .map(|location| hash[location % hash.len()] % 2 == 0)
-        .collect();
-    grid
+        .collect()
 }


### PR DESCRIPTION
Hi

I initially wanted to show off the turbofish with `.collect::<Vec<bool>>()` but then I realized that it is not needed in this context.
This is a purely cosmetic change.

Cheers,
Stefan