### PR TITLE
Add README.md to cargo doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ You can run this example with `cargo run --example main`.
 
 The repository contains an example webservice that you can run with `cargo run --example webserver`.
 
-## TODO
-- add more information to README.md
-- add more examples
-
 ## License
 
 Licensed under either of

--- a/scripts/README_TEMPLATE.md
+++ b/scripts/README_TEMPLATE.md
@@ -30,10 +30,6 @@ You can run this example with `cargo run --example main`.
 
 The repository contains an example webservice that you can run with `cargo run --example webserver`.
 
-## TODO
-- add more information to README.md
-- add more examples
-
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use std::str::FromStr;
 
 use crate::error::IdenticonError;


### PR DESCRIPTION
Add the `README.md` to the cargo doc header.