### PR TITLE
Standardize running rules across actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ $default-branch ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ $default-branch ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Standardizes the running rules of actions that run on `main` branch to use `$default-branch` instead.